### PR TITLE
skip newlines when reading a file

### DIFF
--- a/import_off.py
+++ b/import_off.py
@@ -192,6 +192,8 @@ def load(operator, context, filepath):
     i=0;
     while i<vcount:
         line = file.readline()
+        if line.isspace():
+            continue    # skip empty lines
         try:
              bits = [float(x) for x in line.split()]
              px = bits[0]
@@ -209,6 +211,8 @@ def load(operator, context, filepath):
     i=0;
     while i<fcount:
         line = file.readline()
+        if line.isspace():
+            continue    # skip empty lines
         try:
             splitted  = line.split()
             ids   = list(map(int, splitted))


### PR DESCRIPTION
Hi, thanks for making/maintaining this addon! This pull request is just a small modification to make it compatible with files output by the CGAL library (http://www.cgal.org/), more specifically, the OFF file writer at CGAL/IO/File_writer_OFF.h. It likes to insert an additional newline (empty line) after the file header, which otherwise breaks the addon. This saves me having to manually remove the line every time (or recompile CGAL).