### PR TITLE
Support 2.8x

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,16 +1,20 @@
 # Blender OFF Addon
 
-This addon will add the ability to import and export ascii OFF mesh files in Blender.
+This addon will add the ability to import and export ascii OFF mesh files in Blender 2.8x.
 
 # Quickstart
 
 1. Clone this project.
 2. Open Blender.
-3. Go to File > User Preferences... > Addons tab.
-4. On the bottom, click Install from File...
-5. Select the import_off.py from this project.
+3. Go to Edit > Preferences... > Addons tab.
+4. On the top right, click Install... button.
+5. Select the `import_off.py` from this project.
 6. Check the checkbox by the OFF addon to enable it.
 7. Now you should have new import/export menu items to work with OFF files.
+
+# Older Blender versions
+
+If you are using Blender 2.7x or older, please use the `blender/2.7` branch.
 
 # License + Contributing
 
@@ -20,13 +24,17 @@ This addon is licensed under Apache 2.0.
 
 Please feel free to open an issue/pull request about any problems you have or
 features you'd want to have. I'll do my best to be responsive, but if not,
-feel free to ping me with a mention, or tweet at me.
+feel free to ping me an email or tweet at me.
 
 # Links
 
 Blender Wiki page: http://wiki.blender.org/index.php/Extensions:2.6/Py/Scripts/Import-Export/Object_File_Format_%28.off%29
 
 # Changelog
+
+## 0.4.0 / 2020-05-10
+
+- Support breaking API changes in Blender 2.8x release.
 
 ## 0.3.1 / 2017-11-03
 
@@ -53,4 +61,4 @@ To have your script show up in the Add-Ons panel, it needs to:
 
     be in the addons/ directory
     contain a dictionary called "bl_info"
-    define register() / unregister() functions. 
+    define register() / unregister() functions.

--- a/bl_info.txt
+++ b/bl_info.txt
@@ -7,7 +7,7 @@ bl_info = {
     "description": "Import-Export OFF, Import/export simple OFF mesh.",
     "author": "Alex Tsui, Mateusz Kłoczko",
     "version": (0, 3, 1),
-    "blender": (2, 74, 0),
+    "blender": (2, 80, 0),
     "location": "File > Import-Export",
     "warning": "", # used for warning icon and text in addons panel
     "wiki_url": "http://wiki.blender.org/index.php/Extensions:2.5/Py/"

--- a/bl_info.txt
+++ b/bl_info.txt
@@ -6,7 +6,7 @@ bl_info = {
     "name": "Import-Export OFF",
     "description": "Import-Export OFF, Import/export simple OFF mesh.",
     "author": "Alex Tsui, Mateusz Kłoczko",
-    "version": (0, 3, 1),
+    "version": (0, 4, 0),
     "blender": (2, 80, 0),
     "location": "File > Import-Export",
     "warning": "", # used for warning icon and text in addons panel

--- a/import_off.py
+++ b/import_off.py
@@ -42,7 +42,7 @@ bl_info = {
     "name": "OFF format",
     "description": "Import-Export OFF, Import/export simple OFF mesh.",
     "author": "Alex Tsui, Mateusz Kłoczko",
-    "version": (0, 3),
+    "version": (0, 4, 0),
     "blender": (2, 82, 7),
     "location": "File > Import-Export",
     "warning": "", # used for warning icon and text in addons panel

--- a/import_off.py
+++ b/import_off.py
@@ -43,7 +43,7 @@ bl_info = {
     "description": "Import-Export OFF, Import/export simple OFF mesh.",
     "author": "Alex Tsui, Mateusz Kłoczko",
     "version": (0, 3),
-    "blender": (2, 74, 0),
+    "blender": (2, 80, 0),
     "location": "File > Import-Export",
     "warning": "", # used for warning icon and text in addons panel
     "wiki_url": "http://wiki.blender.org/index.php/Extensions:2.5/Py/"
@@ -100,13 +100,14 @@ class ImportOFF(bpy.types.Operator, ImportHelper):
 
         scene = bpy.context.scene
         obj = bpy.data.objects.new(mesh.name, mesh)
-        scene.objects.link(obj)
+        #scene.objects.link(obj)
+        scene.collection.objects.link(obj)
         scene.objects.active = obj
         obj.select = True
 
         obj.matrix_world = global_matrix
 
-        scene.update()
+        #scene.update()
 
         return {'FINISHED'}
 
@@ -167,15 +168,21 @@ def menu_func_import(self, context):
 def menu_func_export(self, context):
     self.layout.operator(ExportOFF.bl_idname, text="OFF Mesh (.off)")
 
+classes = (
+    ImportOFF,
+    ExportOFF,
+)
+    
 def register():
-    bpy.utils.register_module(__name__)
-    bpy.types.INFO_MT_file_import.append(menu_func_import)
-    bpy.types.INFO_MT_file_export.append(menu_func_export)
-
+    for c in classes:
+        bpy.utils.register_class(c)
+    bpy.types.TOPBAR_MT_file_export.append(menu_func_export)
+    bpy.types.TOPBAR_MT_file_import.append(menu_func_import)
 def unregister():
-    bpy.utils.unregister_module(__name__)
-    bpy.types.INFO_MT_file_import.remove(menu_func_import)
-    bpy.types.INFO_MT_file_export.remove(menu_func_export)
+    for c in reversed(classes):
+        bpy.utils.unregister_class(c)
+    bpy.types.TOPBAR_MT_file_export.remove(menu_func_export)
+    bpy.types.TOPBAR_MT_file_import.remove(menu_func_import)
 
 def load(operator, context, filepath):
     # Parse mesh from OFF file

--- a/import_off.py
+++ b/import_off.py
@@ -267,15 +267,18 @@ def save(operator, context, filepath,
     if global_matrix is None:
         global_matrix = mathutils.Matrix()
     scene = context.scene
-    obj = scene.objects.active
-    mesh = obj.to_mesh(scene, APPLY_MODIFIERS, 'PREVIEW')
+    #obj = scene.objects.active
+    obj = bpy.context.window.scene.objects[0]
+    bpy.context.view_layer.objects.active = obj    # 'obj' is the active object now
+    #mesh = obj.to_mesh(scene, APPLY_MODIFIERS, 'PREVIEW')
+    mesh = obj.to_mesh()
 
     # Apply the inverse transformation
     obj_mat = obj.matrix_world
-    mesh.transform(global_matrix * obj_mat)
+    mesh.transform(global_matrix @ obj_mat)
 
     verts = mesh.vertices[:]
-    facets = [ f for f in mesh.tessfaces ]
+    facets = [ f for f in mesh.polygons ]
     # Collect colors by vertex id
     colors = False
     vertex_colors = None
@@ -284,7 +287,7 @@ def save(operator, context, filepath,
     if colors:
         colors = colors.data
         vertex_colors = {}
-        for i, facet in enumerate(mesh.tessfaces):
+        for i, facet in enumerate(mesh.polygons):
             color = colors[i]
             color = color.color1[:], color.color2[:], color.color3[:], color.color4[:]
             for j, vidx in enumerate(facet.vertices):
@@ -313,7 +316,7 @@ def save(operator, context, filepath,
         fp.write('\n')
 
     #for facet in facets:
-    for i, facet in enumerate(mesh.tessfaces):
+    for i, facet in enumerate(mesh.polygons):
         fp.write('%d' % len(facet.vertices))
         for vid in facet.vertices:
             fp.write(' %d' % vid)

--- a/import_off.py
+++ b/import_off.py
@@ -43,7 +43,7 @@ bl_info = {
     "description": "Import-Export OFF, Import/export simple OFF mesh.",
     "author": "Alex Tsui, Mateusz Kłoczko",
     "version": (0, 3),
-    "blender": (2, 80, 0),
+    "blender": (2, 82, 7),
     "location": "File > Import-Export",
     "warning": "", # used for warning icon and text in addons panel
     "wiki_url": "http://wiki.blender.org/index.php/Extensions:2.5/Py/"
@@ -100,14 +100,12 @@ class ImportOFF(bpy.types.Operator, ImportHelper):
 
         scene = bpy.context.scene
         obj = bpy.data.objects.new(mesh.name, mesh)
-        #scene.objects.link(obj)
         scene.collection.objects.link(obj)
-        scene.objects.active = obj
-        obj.select = True
 
         obj.matrix_world = global_matrix
 
-        #scene.update()
+        layer = bpy.context.view_layer
+        layer.update()
 
         return {'FINISHED'}
 
@@ -263,14 +261,10 @@ def save(operator, context, filepath,
     global_matrix = None,
     use_colors = False):
     # Export the selected mesh
-    APPLY_MODIFIERS = True # TODO: Make this configurable
     if global_matrix is None:
         global_matrix = mathutils.Matrix()
     scene = context.scene
-    #obj = scene.objects.active
-    obj = bpy.context.window.scene.objects[0]
-    bpy.context.view_layer.objects.active = obj    # 'obj' is the active object now
-    #mesh = obj.to_mesh(scene, APPLY_MODIFIERS, 'PREVIEW')
+    obj = bpy.context.view_layer.objects.active
     mesh = obj.to_mesh()
 
     # Apply the inverse transformation


### PR DESCRIPTION
Closes #17 #16

Thanks to @xuser86 for the contribution, and apologies for the year-late response. Recently received an email regarding 2.8x support so that's when I noticed the PR/issue...

This PR adds support for the addon in the recent Blender version and was tested on Blender 2.82.7 (packaged release on Ubuntu 20.04 LTS).

This contains breaking changes for 2.7x and older, so I'll keep that code in a separate `blender/2.7` branch in case someone needs it.

## Relevant links

Details for migrating addon from 2.7x to 2.8x: https://wiki.blender.org/wiki/Reference/Release_Notes/2.80/Python_API